### PR TITLE
Bug/tooltips outside viewport

### DIFF
--- a/packages/tooltip/src/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip.tsx
@@ -15,7 +15,7 @@ export const Tooltip = () => {
     }
 
     return (
-        <TooltipWrapper position={state.position} anchor={state.anchor}>
+        <TooltipWrapper position={state.position} anchor={state.anchor} outer={state.outer}>
             {state.content}
         </TooltipWrapper>
     )

--- a/packages/tooltip/src/TooltipWrapper.tsx
+++ b/packages/tooltip/src/TooltipWrapper.tsx
@@ -62,15 +62,16 @@ export const TooltipWrapper = memo<PropsWithChildren<TooltipWrapperProps>>(
             const x0 = -outer.left;
             const y0 = -outer.top;
 
-            // not sure why but have to adjust by twice scrollbar width
-            const outerWidth = outer.width + 32;
+            // the tooltip is constrained by the window not its container
+            const constrainingWidth = document.documentElement.clientWidth
+            const constrainingHeight = document.documentElement.clientHeight
 
-            if (outer.width > 0 && x > outerWidth - bounds.width + x0){
-                x = outerWidth - bounds.width + x0
+            if (constrainingWidth > 0 && x > constrainingWidth - bounds.width + x0) {
+                x = constrainingWidth - bounds.width + x0
             }
 
-            if (outer.height > 0 && y > outer.height - bounds.height){
-                y = outer.height - bounds.height
+            if (constrainingHeight > 0 && y > constrainingHeight - bounds.height + y0) {
+                y = constrainingHeight - bounds.height + y0
             }
 
             x = Math.max(x, x0)

--- a/packages/tooltip/src/TooltipWrapper.tsx
+++ b/packages/tooltip/src/TooltipWrapper.tsx
@@ -23,10 +23,11 @@ const translate = (x: number, y: number) => `translate(${x}px, ${y}px)`
 interface TooltipWrapperProps {
     position: TooltipStateContextDataVisible['position']
     anchor: TooltipStateContextDataVisible['anchor']
+    outer: TooltipStateContextDataVisible['outer']
 }
 
 export const TooltipWrapper = memo<PropsWithChildren<TooltipWrapperProps>>(
-    ({ position, anchor, children }) => {
+    ({ position, anchor, children, outer }) => {
         const theme = useTheme()
         const { animate, config: springConfig } = useMotionConfig()
         const [measureRef, bounds] = useMeasure()
@@ -56,6 +57,24 @@ export const TooltipWrapper = memo<PropsWithChildren<TooltipWrapperProps>>(
                 x -= bounds.width / 2
                 y -= bounds.height / 2
             }
+
+            // when scrolled, outer.left becomes negative by the scroll offset, so this is the minimum value visible
+            const x0 = -outer.left;
+            const y0 = -outer.top;
+
+            // not sure why but have to adjust by twice scrollbar width
+            const outerWidth = outer.width + 32;
+
+            if (outer.width > 0 && x > outerWidth - bounds.width + x0){
+                x = outerWidth - bounds.width + x0
+            }
+
+            if (outer.height > 0 && y > outer.height - bounds.height){
+                y = outer.height - bounds.height
+            }
+
+            x = Math.max(x, x0)
+            y = Math.max(y, y0)
 
             to = {
                 transform: translate(x, y),

--- a/packages/tooltip/src/context.ts
+++ b/packages/tooltip/src/context.ts
@@ -24,6 +24,14 @@ export interface TooltipStateContextDataVisible {
     position: [number, number]
     content: JSX.Element
     anchor: TooltipAnchor
+    outer: Rectangle
+}
+
+export interface Rectangle {
+    left: number
+    top: number
+    height: number
+    width: number
 }
 
 export interface TooltipStateContextDataHidden {

--- a/packages/tooltip/src/hooks.ts
+++ b/packages/tooltip/src/hooks.ts
@@ -13,11 +13,13 @@ export const useTooltipHandlers = (container: MutableRefObject<HTMLDivElement>) 
 
     const showTooltipAt: TooltipActionsContextData['showTooltipAt'] = useCallback(
         (content: JSX.Element, [x, y]: [number, number], anchor: TooltipAnchor = 'top') => {
+            const bounds = container.current.getBoundingClientRect()
             setState({
                 isVisible: true,
                 position: [x, y],
                 anchor,
                 content,
+                outer: bounds
             })
         },
         [setState]
@@ -39,6 +41,7 @@ export const useTooltipHandlers = (container: MutableRefObject<HTMLDivElement>) 
                 position: [x, y],
                 anchor,
                 content,
+                outer: bounds
             })
         },
         [container, setState]


### PR DESCRIPTION
Adjusts the x and y of the displayed tooltip to be within the window viewport, compensating for scrolling of the container it is positioned relative to.