### PR TITLE
Pie chart label overlap

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../**/*.stories.@(js|tsx)'],
+  stories: ['../packages/**/*.stories.@(js|tsx)'],
   addons: [
     '@storybook/addon-knobs',
     '@storybook/addon-actions',

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "make:init": "make init",
     "prepublishOnly": "yarn release:prepare",
     "release:prepare": "node scripts/bump-peer-deps.js",
-    "version": "yarn release:prepare"
+    "version": "yarn release:prepare",
+    "storybook": "start-storybook -p 9001"
   },
   "workspaces": [
     "packages/*",

--- a/packages/arcs/src/arc_labels/canvas.ts
+++ b/packages/arcs/src/arc_labels/canvas.ts
@@ -2,6 +2,15 @@ import { CompleteTheme } from '@bitbloom/nivo-core'
 import { DatumWithArcAndColor } from '../types'
 import { ArcLabel } from './useArcLabels'
 
+function intersects(a: DOMRect, b?: DOMRect): boolean {
+    if (!b) return false
+    if (a.left > b.right) return false
+    if (a.top > b.bottom) return false
+    if (a.right < b.left) return false
+    if (a.bottom < b.top) return false
+    return true
+}
+
 export const drawCanvasArcLabels = <Datum extends DatumWithArcAndColor>(
     ctx: CanvasRenderingContext2D,
     labels: ArcLabel<Datum>[],
@@ -11,7 +20,32 @@ export const drawCanvasArcLabels = <Datum extends DatumWithArcAndColor>(
     ctx.textBaseline = 'middle'
     ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily}`
 
+    const dimensions: { [key: string]: DOMRect } = {}
+
     labels.forEach(label => {
+        ctx.fillStyle = label.textColor
+        const textMetrics = ctx.measureText(`${label.label}`)
+        const spacing = 1
+        let left = label.x - textMetrics.actualBoundingBoxLeft
+        let top = label.y - Math.abs(textMetrics.actualBoundingBoxAscent) - spacing
+        let right = label.x + textMetrics.actualBoundingBoxRight
+        let bottom = label.y + Math.abs(textMetrics.actualBoundingBoxDescent)
+        const bounds = new DOMRect(left, top, right - left, bottom - top)
+
+        dimensions[label.data.id] = bounds
+    })
+
+    const avoid: DOMRect[] = []
+
+    labels.forEach(label => {
+        const bounds = dimensions[label.data.id]
+
+        if (avoid.reduce((found: boolean, rect: DOMRect) => found || intersects(bounds, rect), false)) {
+            return;
+        }
+
+        avoid.push(bounds)
+
         ctx.fillStyle = label.textColor
         ctx.fillText(`${label.label}`, label.x, label.y)
     })

--- a/packages/arcs/src/arc_labels/canvas.ts
+++ b/packages/arcs/src/arc_labels/canvas.ts
@@ -1,15 +1,7 @@
 import { CompleteTheme } from '@bitbloom/nivo-core'
 import { DatumWithArcAndColor } from '../types'
+import { intersects } from '../utils'
 import { ArcLabel } from './useArcLabels'
-
-function intersects(a: DOMRect, b?: DOMRect): boolean {
-    if (!b) return false
-    if (a.left > b.right) return false
-    if (a.top > b.bottom) return false
-    if (a.right < b.left) return false
-    if (a.bottom < b.top) return false
-    return true
-}
 
 export const drawCanvasArcLabels = <Datum extends DatumWithArcAndColor>(
     ctx: CanvasRenderingContext2D,

--- a/packages/arcs/src/arc_link_labels/ArcLinkLabelsLayer.tsx
+++ b/packages/arcs/src/arc_link_labels/ArcLinkLabelsLayer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import { usePropertyAccessor } from '@bitbloom/nivo-core'
 import { DatumWithArcAndColor } from '../types'
 import { useArcLinkLabelsTransition } from './useArcLinkLabelsTransition'
@@ -12,6 +12,7 @@ export type ArcLinkLabelComponent<Datum extends DatumWithArcAndColor> = (
 interface ArcLinkLabelsLayerProps<Datum extends DatumWithArcAndColor> {
     center: [number, number]
     data: Datum[]
+    activeId?: string
     label: ArcLinkLabelsProps<Datum>['arcLinkLabel']
     skipAngle: ArcLinkLabelsProps<Datum>['arcLinkLabelsSkipAngle']
     offset: ArcLinkLabelsProps<Datum>['arcLinkLabelsOffset']
@@ -27,7 +28,8 @@ interface ArcLinkLabelsLayerProps<Datum extends DatumWithArcAndColor> {
 export const ArcLinkLabelsLayer = <Datum extends DatumWithArcAndColor>({
     center,
     data,
-    label: labelAccessor,
+    activeId,
+    label,
     skipAngle,
     offset,
     diagonalLength,
@@ -38,8 +40,6 @@ export const ArcLinkLabelsLayer = <Datum extends DatumWithArcAndColor>({
     linkColor,
     component = ArcLinkLabel,
 }: ArcLinkLabelsLayerProps<Datum>) => {
-    const getLabel = usePropertyAccessor<Datum, string>(labelAccessor)
-
     const {
         transition,
         interpolateLink,
@@ -56,46 +56,130 @@ export const ArcLinkLabelsLayer = <Datum extends DatumWithArcAndColor>({
         textColor,
     })
 
-    const Label: ArcLinkLabelComponent<Datum> = component
+    const [clip, setClip] = useState<{ dimensions: { [key: string]: DOMRect }, active?: DOMRect[], dimsRequired: number, activeId?: string }>({
+        dimensions: {},
+        dimsRequired: data.length,
+        activeId
+    })
+
+    if (clip.activeId !== activeId) {
+        // clears cached label dimensions if active label changes
+        setClip({
+            dimensions: {},
+            dimsRequired: data.length,
+            activeId
+        })
+    }
 
     return (
         <g transform={`translate(${center[0]},${center[1]})`}>
-            {transition((transitionProps, datum) => {
-                return React.createElement(Label, {
-                    key: datum.id,
-                    datum,
-                    label: getLabel(datum),
-                    style: {
-                        ...transitionProps,
-                        thickness: strokeWidth,
-                        path: interpolateLink(
-                            transitionProps.startAngle,
-                            transitionProps.endAngle,
-                            transitionProps.innerRadius,
-                            transitionProps.outerRadius,
-                            transitionProps.offset,
-                            transitionProps.diagonalLength,
-                            transitionProps.straightLength
-                        ),
-                        textAnchor: interpolateTextAnchor(
-                            transitionProps.startAngle,
-                            transitionProps.endAngle,
-                            transitionProps.innerRadius,
-                            transitionProps.outerRadius
-                        ),
-                        textPosition: interpolateTextPosition(
-                            transitionProps.startAngle,
-                            transitionProps.endAngle,
-                            transitionProps.innerRadius,
-                            transitionProps.outerRadius,
-                            transitionProps.offset,
-                            transitionProps.diagonalLength,
-                            transitionProps.straightLength,
-                            transitionProps.textOffset
-                        ),
-                    },
-                })
-            })}
+            {[true, false].map(active => transition((transitionProps, datum) => active == (datum.id == activeId) && <ArcLinkLabelItem
+                clip={clip}
+                setClip={setClip}
+                component={component}
+                label={label}
+                strokeWidth={strokeWidth}
+                transitionProps={transitionProps}
+                datum={datum}
+                key={datum.id}
+                activeId={activeId}
+                interpolateLink={interpolateLink}
+                interpolateTextAnchor={interpolateTextAnchor}
+                interpolateTextPosition={interpolateTextPosition} />))}
         </g>
     )
+}
+
+function intersects(a: DOMRect, b?: DOMRect): boolean {
+    if (!b) return false
+    const inset = 0 // allow small amount of overlap of bounds as usually won't obscure text
+    if (a.left > b.right - inset) return false
+    if (a.top > b.bottom - inset) return false
+    if (a.right < b.left + inset) return false
+    if (a.bottom < b.top + inset) return false
+    return true
+}
+
+function ArcLinkLabelItem<Datum extends DatumWithArcAndColor>({
+    clip,
+    setClip,
+    activeId,
+    component,
+    label,
+    strokeWidth,
+    transitionProps,
+    datum,
+    interpolateLink,
+    interpolateTextAnchor,
+    interpolateTextPosition,
+}: any) {
+    const getLabel = usePropertyAccessor<Datum, string>(label)
+    const Label: ArcLinkLabelComponent<Datum> = component
+    const dimensions = clip.dimensions[datum.id]
+
+    const ref = useCallback((domNode: SVGElement | null) => {
+        if (domNode) {
+            // the intention is to gather dimensions of all labels then update the state of the parent 
+            // to re-render once all the dimensions are gathered
+            const hasDims = !!clip.dimensions[datum.id]
+            clip.dimensions[datum.id] = domNode.getBoundingClientRect()
+            if (!hasDims) {
+                --clip.dimsRequired
+                if (clip.dimsRequired === 0) setClip({ ...clip, active: [] })
+            }
+        }
+    }, [setClip])
+
+    let clipped = true
+
+    console.log(`${datum.id} activeId`, activeId)
+    console.log(`${datum.id} dimensions`, dimensions)
+
+    if (dimensions && clip.active) {
+        if (datum.id == activeId ||
+            !clip.active.reduce((found: boolean, rect: DOMRect) => found || intersects(dimensions, rect), false)) {
+            clipped = false
+            clip.active.push(dimensions)
+        }
+    } else if (!dimensions) {
+        clip.dimensions[datum.id] = null
+    }
+
+    console.log(`${datum.id} clipped`, clipped)
+    console.log(`${datum.id} clip`, clip)
+
+
+    const opacity = clipped ? 0.05 : (activeId && datum.id !== activeId ? 0.5 : 1)
+    const style = {
+        ...transitionProps,
+        opacity,
+        thickness: strokeWidth,
+        path: interpolateLink(
+            transitionProps.startAngle,
+            transitionProps.endAngle,
+            transitionProps.innerRadius,
+            transitionProps.outerRadius,
+            transitionProps.offset,
+            transitionProps.diagonalLength,
+            transitionProps.straightLength
+        ),
+        textAnchor: interpolateTextAnchor(
+            transitionProps.startAngle,
+            transitionProps.endAngle,
+            transitionProps.innerRadius,
+            transitionProps.outerRadius
+        ),
+        textPosition: interpolateTextPosition(
+            transitionProps.startAngle,
+            transitionProps.endAngle,
+            transitionProps.innerRadius,
+            transitionProps.outerRadius,
+            transitionProps.offset,
+            transitionProps.diagonalLength,
+            transitionProps.straightLength,
+            transitionProps.textOffset
+        )
+    }
+
+    return <g ref={ref} key={datum.id}>{React.createElement(Label, { datum, label: getLabel(datum), style })}</g>
 }

--- a/packages/arcs/src/arc_link_labels/ArcLinkLabelsLayer.tsx
+++ b/packages/arcs/src/arc_link_labels/ArcLinkLabelsLayer.tsx
@@ -12,7 +12,7 @@ export type ArcLinkLabelComponent<Datum extends DatumWithArcAndColor> = (
 interface ArcLinkLabelsLayerProps<Datum extends DatumWithArcAndColor> {
     center: [number, number]
     data: Datum[]
-    activeId?: string
+    activeId?: string | number
     label: ArcLinkLabelsProps<Datum>['arcLinkLabel']
     skipAngle: ArcLinkLabelsProps<Datum>['arcLinkLabelsSkipAngle']
     offset: ArcLinkLabelsProps<Datum>['arcLinkLabelsOffset']
@@ -23,6 +23,17 @@ interface ArcLinkLabelsLayerProps<Datum extends DatumWithArcAndColor> {
     textColor: ArcLinkLabelsProps<Datum>['arcLinkLabelsTextColor']
     linkColor: ArcLinkLabelsProps<Datum>['arcLinkLabelsColor']
     component?: ArcLinkLabelComponent<Datum>
+}
+
+interface ClipType {
+    /** dimensions for each label to clip */
+    dimensions: { [key: string]: DOMRect }
+    /** rectangles already rendered which should be avoided */
+    avoid?: DOMRect[]
+    /** number of dimensions required before can perform clipping */
+    dimsRequired: number
+    /** id of active label, which is always shown */
+    activeId?: string | number
 }
 
 export const ArcLinkLabelsLayer = <Datum extends DatumWithArcAndColor>({
@@ -56,7 +67,7 @@ export const ArcLinkLabelsLayer = <Datum extends DatumWithArcAndColor>({
         textColor,
     })
 
-    const [clip, setClip] = useState<{ dimensions: { [key: string]: DOMRect }, active?: DOMRect[], dimsRequired: number, activeId?: string }>({
+    const [clip, setClip] = useState<ClipType>({
         dimensions: {},
         dimsRequired: data.length,
         activeId
@@ -64,9 +75,22 @@ export const ArcLinkLabelsLayer = <Datum extends DatumWithArcAndColor>({
 
     if (clip.activeId !== activeId) {
         // clears cached label dimensions if active label changes
+        const dimensions = { ...clip.dimensions }
+        let dimsRequired = 0
+
+        if (clip.activeId) {
+            delete dimensions[clip.activeId]
+            ++dimsRequired
+        }
+
+        if (activeId) {
+            delete dimensions[activeId]
+            ++dimsRequired
+        }
+
         setClip({
-            dimensions: {},
-            dimsRequired: data.length,
+            dimensions,
+            dimsRequired,
             activeId
         })
     }
@@ -92,12 +116,25 @@ export const ArcLinkLabelsLayer = <Datum extends DatumWithArcAndColor>({
 
 function intersects(a: DOMRect, b?: DOMRect): boolean {
     if (!b) return false
-    const inset = 0 // allow small amount of overlap of bounds as usually won't obscure text
-    if (a.left > b.right - inset) return false
-    if (a.top > b.bottom - inset) return false
-    if (a.right < b.left + inset) return false
-    if (a.bottom < b.top + inset) return false
+    if (a.left > b.right) return false
+    if (a.top > b.bottom) return false
+    if (a.right < b.left) return false
+    if (a.bottom < b.top) return false
     return true
+}
+
+interface ArcLinkLabelItemProps<Datum extends DatumWithArcAndColor> {
+    clip: ClipType
+    setClip: (clip: ClipType) => void
+    activeId?: string | number
+    component: any
+    label: ArcLinkLabelsProps<Datum>['arcLinkLabel']
+    strokeWidth: number
+    transitionProps: any
+    datum: Datum
+    interpolateLink: any
+    interpolateTextAnchor: any
+    interpolateTextPosition: any
 }
 
 function ArcLinkLabelItem<Datum extends DatumWithArcAndColor>({
@@ -112,7 +149,7 @@ function ArcLinkLabelItem<Datum extends DatumWithArcAndColor>({
     interpolateLink,
     interpolateTextAnchor,
     interpolateTextPosition,
-}: any) {
+}: ArcLinkLabelItemProps<Datum>) {
     const getLabel = usePropertyAccessor<Datum, string>(label)
     const Label: ArcLinkLabelComponent<Datum> = component
     const dimensions = clip.dimensions[datum.id]
@@ -125,29 +162,22 @@ function ArcLinkLabelItem<Datum extends DatumWithArcAndColor>({
             clip.dimensions[datum.id] = domNode.getBoundingClientRect()
             if (!hasDims) {
                 --clip.dimsRequired
-                if (clip.dimsRequired === 0) setClip({ ...clip, active: [] })
+                if (clip.dimsRequired === 0) setClip({ ...clip, avoid: [] })
             }
         }
-    }, [setClip])
+    }, [setClip, activeId])
 
     let clipped = true
 
-    console.log(`${datum.id} activeId`, activeId)
-    console.log(`${datum.id} dimensions`, dimensions)
-
-    if (dimensions && clip.active) {
+    if (dimensions && clip.avoid) {
         if (datum.id == activeId ||
-            !clip.active.reduce((found: boolean, rect: DOMRect) => found || intersects(dimensions, rect), false)) {
+            !clip.avoid.reduce((found: boolean, rect: DOMRect) => found || intersects(dimensions, rect), false)) {
             clipped = false
-            clip.active.push(dimensions)
+            clip.avoid.push(dimensions)
         }
     } else if (!dimensions) {
-        clip.dimensions[datum.id] = null
+        delete clip.dimensions[datum.id]
     }
-
-    console.log(`${datum.id} clipped`, clipped)
-    console.log(`${datum.id} clip`, clip)
-
 
     const opacity = clipped ? 0.05 : (activeId && datum.id !== activeId ? 0.5 : 1)
     const style = {

--- a/packages/arcs/src/arc_link_labels/ArcLinkLabelsLayer.tsx
+++ b/packages/arcs/src/arc_link_labels/ArcLinkLabelsLayer.tsx
@@ -4,6 +4,7 @@ import { DatumWithArcAndColor } from '../types'
 import { useArcLinkLabelsTransition } from './useArcLinkLabelsTransition'
 import { ArcLinkLabelsProps } from './props'
 import { ArcLinkLabel, ArcLinkLabelProps } from './ArcLinkLabel'
+import { intersects } from '../utils'
 
 export type ArcLinkLabelComponent<Datum extends DatumWithArcAndColor> = (
     props: ArcLinkLabelProps<Datum>
@@ -112,15 +113,6 @@ export const ArcLinkLabelsLayer = <Datum extends DatumWithArcAndColor>({
                 interpolateTextPosition={interpolateTextPosition} />))}
         </g>
     )
-}
-
-function intersects(a: DOMRect, b?: DOMRect): boolean {
-    if (!b) return false
-    if (a.left > b.right) return false
-    if (a.top > b.bottom) return false
-    if (a.right < b.left) return false
-    if (a.bottom < b.top) return false
-    return true
 }
 
 interface ArcLinkLabelItemProps<Datum extends DatumWithArcAndColor> {

--- a/packages/arcs/src/arc_link_labels/canvas.ts
+++ b/packages/arcs/src/arc_link_labels/canvas.ts
@@ -59,7 +59,9 @@ export const drawCanvasArcLinkLabels = <Datum extends DatumWithArcAndColor>(
         }
     })
 
-    labels.forEach(label => {
+    const quarters = quarterLabels(labels)
+
+    quarters.forEach(label => {
         const bounds = dimensions[label.data.id]
 
         if (label.data.id !== activeId &&
@@ -86,3 +88,32 @@ export const drawCanvasArcLinkLabels = <Datum extends DatumWithArcAndColor>(
 
     ctx.globalAlpha = 1
 }
+
+/**
+ * Sorts the labels so that each quarter is processed from the middle out, meaning that the top 
+ * and bottom labels on each side always appear, otherwise there tends to be a large looking gap.
+ * @param labels labels
+ * @returns labels sorted by quarter
+ */
+function quarterLabels<Datum extends DatumWithArcAndColor>(labels: ArcLinkLabel<Datum>[]) {
+    let result: ArcLinkLabel<Datum>[] = []
+
+    function labelIsInQuarter(label: ArcLinkLabel<Datum>, quarter: number) {
+        const angle = (label.data.arc.startAngle + label.data.arc.endAngle) / 2
+        return (Math.floor(angle / (Math.PI / 2)) + 4) % 4 === quarter
+    }
+
+    for (let quarter = 0; quarter < 4; ++quarter) {
+        const labelsInQuarter = labels.filter(label => labelIsInQuarter(label, quarter))
+
+        if (0 === quarter % 2) {
+            labelsInQuarter.sort((a, b) => a.data.arc.startAngle - b.data.arc.startAngle)
+        } else {
+            labelsInQuarter.sort((a, b) => b.data.arc.startAngle - a.data.arc.startAngle)
+        }
+        result = result.concat(labelsInQuarter)
+    }
+
+    return result
+}
+

--- a/packages/arcs/src/arc_link_labels/canvas.ts
+++ b/packages/arcs/src/arc_link_labels/canvas.ts
@@ -6,17 +6,71 @@ import {
 import { DatumWithArcAndColor } from '../types'
 import { ArcLinkLabel } from './types'
 
+type DatumId = string | number
+
+function intersects(a: DOMRect, b?: DOMRect): boolean {
+    if (!b) return false
+    if (a.left > b.right) return false
+    if (a.top > b.bottom) return false
+    if (a.right < b.left) return false
+    if (a.bottom < b.top) return false
+    return true
+}
+
 export const drawCanvasArcLinkLabels = <Datum extends DatumWithArcAndColor>(
     ctx: CanvasRenderingContext2D,
     labels: ArcLinkLabel<Datum>[],
     theme: CompleteTheme,
-    strokeWidth: number
+    strokeWidth: number,
+    activeId?: DatumId
 ) => {
     ctx.textBaseline = 'middle'
     ctx.font = `${theme.labels.text.fontSize}px ${theme.labels.text.fontFamily}`
 
+    const opacity = activeId === undefined ? 1 : 0.5
+    const dimensions: { [key: string]: DOMRect } = {}
+    const avoid: DOMRect[] = []
+
     labels.forEach(label => {
         ctx.fillStyle = label.textColor
+        ctx.textAlign = textPropsByEngine.canvas.align[label.textAnchor]
+
+        const textMetrics = ctx.measureText(`${label.label}`)
+        const spacing = 1
+        let left = label.x - textMetrics.actualBoundingBoxLeft
+        let top = label.y - Math.abs(textMetrics.actualBoundingBoxAscent) - spacing
+        let right = label.x + textMetrics.actualBoundingBoxRight
+        let bottom = label.y + Math.abs(textMetrics.actualBoundingBoxDescent)
+
+        label.points.forEach((point, index) => {
+            if (index === 0) return
+            left = Math.min(left, point.x)
+            right = Math.max(right, point.x)
+            top = Math.min(top, point.y)
+            bottom = Math.max(bottom, point.y)
+        })
+
+        const bounds = new DOMRect(left, top, right - left, bottom - top)
+
+        dimensions[label.data.id] = bounds
+
+        if (label.data.id == activeId) {
+            avoid.push(bounds)
+        }
+    })
+
+    labels.forEach(label => {
+        const bounds = dimensions[label.data.id]
+
+        if (label.data.id !== activeId &&
+            avoid.reduce((found: boolean, rect: DOMRect) => found || intersects(bounds, rect), false)) {
+            return;
+        }
+
+        avoid.push(bounds)
+
+        ctx.fillStyle = label.textColor
+        ctx.globalAlpha = label.data.id === activeId ? 1 : opacity
         ctx.textAlign = textPropsByEngine.canvas.align[label.textAnchor]
         ctx.fillText(`${label.label}`, label.x, label.y)
 
@@ -29,4 +83,6 @@ export const drawCanvasArcLinkLabels = <Datum extends DatumWithArcAndColor>(
         })
         ctx.stroke()
     })
+
+    ctx.globalAlpha = 1
 }

--- a/packages/arcs/src/arc_link_labels/canvas.ts
+++ b/packages/arcs/src/arc_link_labels/canvas.ts
@@ -4,18 +4,10 @@ import {
     CompleteTheme,
 } from '@bitbloom/nivo-core'
 import { DatumWithArcAndColor } from '../types'
+import { intersects } from '../utils'
 import { ArcLinkLabel } from './types'
 
 type DatumId = string | number
-
-function intersects(a: DOMRect, b?: DOMRect): boolean {
-    if (!b) return false
-    if (a.left > b.right) return false
-    if (a.top > b.bottom) return false
-    if (a.right < b.left) return false
-    if (a.bottom < b.top) return false
-    return true
-}
 
 export const drawCanvasArcLinkLabels = <Datum extends DatumWithArcAndColor>(
     ctx: CanvasRenderingContext2D,
@@ -116,4 +108,3 @@ function quarterLabels<Datum extends DatumWithArcAndColor>(labels: ArcLinkLabel<
 
     return result
 }
-

--- a/packages/arcs/src/utils.ts
+++ b/packages/arcs/src/utils.ts
@@ -33,3 +33,18 @@ export const useFilteredDataBySkipAngle = <Datum extends DatumWithArc>(
     data: Datum[],
     skipAngle: number
 ) => useMemo(() => filterDataBySkipAngle(data, skipAngle), [data, skipAngle])
+
+/**
+ * Test whether two rectangles intersect.
+ * @param a a rectangle
+ * @param b another rectangle
+ * @returns true if they intersect
+ */
+export function intersects(a: DOMRect, b?: DOMRect): boolean {
+    if (!b) return false
+    if (a.left > b.right) return false
+    if (a.top > b.bottom) return false
+    if (a.right < b.left) return false
+    if (a.bottom < b.top) return false
+    return true
+}

--- a/packages/pie/src/Arcs.tsx
+++ b/packages/pie/src/Arcs.tsx
@@ -14,7 +14,7 @@ interface ArcsProps<RawDatum> {
     onMouseEnter?: CompletePieSvgProps<RawDatum>['onMouseEnter']
     onMouseMove?: CompletePieSvgProps<RawDatum>['onMouseMove']
     onMouseLeave?: CompletePieSvgProps<RawDatum>['onMouseLeave']
-    setActiveId: (id: null | string | number) => void
+    setActiveId: (id: undefined | string | number) => void
     tooltip: CompletePieSvgProps<RawDatum>['tooltip']
     transitionMode: CompletePieSvgProps<RawDatum>['transitionMode']
 }
@@ -68,7 +68,7 @@ export const Arcs = <RawDatum,>({
 
         return (datum: ComputedDatum<RawDatum>, event: React.MouseEvent<SVGPathElement>) => {
             hideTooltip()
-            setActiveId(null)
+            setActiveId(undefined)
             onMouseLeave?.(datum, event)
         }
     }, [isInteractive, hideTooltip, setActiveId, onMouseLeave])

--- a/packages/pie/src/Pie.tsx
+++ b/packages/pie/src/Pie.tsx
@@ -102,6 +102,7 @@ const InnerPie = <RawDatum,>({
         radius,
         innerRadius,
         setActiveId,
+        activeId
     } = usePieFromBox<RawDatum>({
         data: normalizedData,
         width: innerWidth,
@@ -130,6 +131,7 @@ const InnerPie = <RawDatum,>({
         layerById.arcLinkLabels = (
             <ArcLinkLabelsLayer<ComputedDatum<RawDatum>>
                 key="arcLinkLabels"
+                activeId={activeId}
                 center={[centerX, centerY]}
                 data={dataWithArc}
                 label={arcLinkLabel}

--- a/packages/pie/src/PieCanvas.tsx
+++ b/packages/pie/src/PieCanvas.tsx
@@ -95,6 +95,7 @@ const InnerPieCanvas = <RawDatum,>({
         radius,
         innerRadius,
         setActiveId,
+        activeId
     } = usePieFromBox<RawDatum>({
         data: normalizedData,
         width: innerWidth,
@@ -173,7 +174,8 @@ const InnerPieCanvas = <RawDatum,>({
                 ctx,
                 arcLinkLabels,
                 theme,
-                arcLinkLabelsThickness
+                arcLinkLabelsThickness,
+                activeId
             )
         }
 
@@ -254,7 +256,7 @@ const InnerPieCanvas = <RawDatum,>({
             setActiveId(datum.id)
             showTooltipFromEvent(createElement(tooltip, { datum }), event)
         } else {
-            setActiveId(null)
+            setActiveId(undefined)
             hideTooltip()
         }
     }

--- a/packages/pie/src/hooks.ts
+++ b/packages/pie/src/hooks.ts
@@ -310,6 +310,7 @@ export const usePieFromBox = <RawDatum>({
         dataWithArc,
         arcGenerator,
         setActiveId,
+        activeId,
         ...computedProps,
     }
 }

--- a/packages/pie/src/hooks.ts
+++ b/packages/pie/src/hooks.ts
@@ -88,7 +88,7 @@ export const usePieArcs = <RawDatum>({
     outerRadius: number
     padAngle: number
     sortByValue: boolean
-    activeId: null | DatumId
+    activeId: undefined | DatumId
     activeInnerRadiusOffset: number
     activeOuterRadiusOffset: number
 }): Omit<ComputedDatum<RawDatum>, 'fill'>[] => {
@@ -183,7 +183,7 @@ export const usePie = <RawDatum>({
     radius: number
     innerRadius: number
 }) => {
-    const [activeId, setActiveId] = useState<DatumId | null>(null)
+    const [activeId, setActiveId] = useState<DatumId | undefined>(undefined)
     const dataWithArc = usePieArcs({
         data,
         startAngle,
@@ -239,7 +239,7 @@ export const usePieFromBox = <RawDatum>({
 > & {
     data: Omit<ComputedDatum<RawDatum>, 'arc'>[]
 }) => {
-    const [activeId, setActiveId] = useState<string | number | null>(null)
+    const [activeId, setActiveId] = useState<string | number | undefined>(undefined)
     const computedProps = useMemo(() => {
         let radius = Math.min(width, height) / 2
         let innerRadius = radius * Math.min(innerRadiusRatio, 1)

--- a/packages/pie/stories/pie.stories.tsx
+++ b/packages/pie/stories/pie.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import { withKnobs, boolean } from '@storybook/addon-knobs'
 import { animated } from 'react-spring'
 import { generateProgrammingLanguageStats } from '@bitbloom/nivo-generators'
-import { Pie } from '../src'
+import { Pie, PieCanvas } from '../src'
 
 const commonProperties = {
     width: 900,
@@ -162,9 +162,21 @@ function generateManyValues(count: number) {
     return result
 }
 
-stories.add('many values', () => (
+stories.add('many values (SVG)', () => (
     <Pie
         {...commonProperties}
+        width={900}
+        height={900}
+        sliceLabelsRadiusOffset={0.7}
+        data={generateManyValues(240)}
+    />
+))
+
+stories.add('many values (Canvas)', () => (
+    <PieCanvas
+        {...commonProperties}
+        width={900}
+        height={900}
         sliceLabelsRadiusOffset={0.7}
         data={generateManyValues(240)}
     />

--- a/packages/pie/stories/pie.stories.tsx
+++ b/packages/pie/stories/pie.stories.tsx
@@ -154,6 +154,22 @@ stories.add('formatted values', () => (
     />
 ))
 
+function generateManyValues(count: number) {
+    const result: { id: string, value: string }[] = []
+    for (let i = 0; i < count; ++i) {
+        result.push({ id: `item${i}`, value: Math.floor(50 + Math.random() * 100).toFixed(0) })
+    }
+    return result
+}
+
+stories.add('many values', () => (
+    <Pie
+        {...commonProperties}
+        sliceLabelsRadiusOffset={0.7}
+        data={generateManyValues(240)}
+    />
+))
+
 stories.add('custom tooltip', () => (
     <Pie
         {...commonProperties}


### PR DESCRIPTION
Adds a couple of stories to the storybook for pie charts with many segments, SVG and Canvas.

Calculates the bounds of each label and hides some labels so they don't overlap.

The label for the segment which is being hovered should always be shown.

Further improvement to https://github.com/BitBloomTech/sift-monitor-ui/issues/370