### PR TITLE
Use a class to specify the container to use for clipping tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "make:init": "make init",
     "prepublishOnly": "yarn release:prepare",
     "release:prepare": "node scripts/bump-peer-deps.js",
-    "version": "yarn release:prepare"
+    "version": "yarn release:prepare",
+    "storybook": "start-storybook -p 9001"
   },
   "workspaces": [
     "packages/*",

--- a/packages/heatmap/stories/heatmap.stories.js
+++ b/packages/heatmap/stories/heatmap.stories.js
@@ -138,3 +138,87 @@ stories.add('custom tooltip', () => (
         }}
     />
 ))
+
+stories.add('large tooltip', () => (
+    <div style={{ backgroundColor: 'pink', overflow: 'hidden' }} className='tooltip-clip'>
+        <div
+            style={{ overflow: 'auto', position: 'relative', backgroundColor: 'greenyellow' }}
+            className='tooltip-clip'
+        >
+            <div
+                style={{
+                    display: 'inline-block',
+                    float: 'right',
+                    backgroundColor: 'skyblue',
+                    overflow: 'hidden',
+                    width: '100%',
+                }}
+            >
+                <HeatMap
+                    {...commonProperties}
+                    tooltip={({ xKey, yKey, value, color }) => (
+                        <strong style={{ color }}>
+                            ⭐-------------------------------- {xKey} / {yKey}: {value}{' '}
+                            --------------------------------⭐
+                        </strong>
+                    )}
+                    theme={{
+                        tooltip: {
+                            container: {
+                                background: 'gray',
+                            },
+                        },
+                    }}
+                />
+            </div>
+        </div>
+        <div
+            style={{ overflow: 'auto', position: 'relative', backgroundColor: 'greenyellow' }}
+            className='tooltip-clip'
+        >
+            <div style={{ width: '200vw' }}>
+                <div
+                    style={{
+                        position: 'relative',
+                        marginLeft: '40vw',
+                        marginRight: '40vw',
+                        backgroundColor: 'skyblue',
+                    }}
+                >
+                    <HeatMap
+                        {...commonProperties}
+                        tooltip={({ xKey, yKey, value, color }) => (
+                            <strong style={{ color }}>
+                                ⭐-------------------------------- {xKey} / {yKey}: {value}{' '}
+                                --------------------------------⭐
+                            </strong>
+                        )}
+                        theme={{
+                            tooltip: {
+                                container: {
+                                    background: 'gray',
+                                },
+                            },
+                        }}
+                    />
+                </div>
+            </div>
+        </div>
+        <HeatMap
+            {...commonProperties}
+            tooltip={({ xKey, yKey, value, color }) => (
+                <strong style={{ color }}>
+                    ⭐-------------------------------- {xKey} / {yKey}: {value}{' '}
+                    --------------------------------⭐
+                </strong>
+            )}
+            theme={{
+                tooltip: {
+                    container: {
+                        background: 'gray',
+                    },
+                },
+            }}
+        />
+    </div>
+))


### PR DESCRIPTION
Trying to create a heuristic for the right container didn't work consistently, so have the client code mark it explicitly to remove ambiguity, and not clip the tooltips if no such container is found.