### PR TITLE
Add `exports` config value for Vitest compatibility

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -26,6 +26,12 @@
     "main": "./dist/nivo-annotations.cjs.js",
     "module": "./dist/nivo-annotations.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-annotations.cjs.js",
+        "import": "./dist/nivo-annotations.es.js",
+        "default": "./dist/nivo-annotations.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/arcs/package.json
+++ b/packages/arcs/package.json
@@ -21,6 +21,12 @@
     "main": "./dist/nivo-arcs.cjs.js",
     "module": "./dist/nivo-arcs.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-arcs.cjs.js",
+        "import": "./dist/nivo-arcs.es.js",
+        "default": "./dist/nivo-arcs.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/axes/package.json
+++ b/packages/axes/package.json
@@ -20,6 +20,12 @@
     "main": "./dist/nivo-axes.cjs.js",
     "module": "./dist/nivo-axes.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-axes.cjs.js",
+        "import": "./dist/nivo-axes.es.js",
+        "default": "./dist/nivo-axes.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/bar/package.json
+++ b/packages/bar/package.json
@@ -17,6 +17,12 @@
     "main": "./dist/nivo-bar.cjs.js",
     "module": "./dist/nivo-bar.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-bar.cjs.js",
+        "import": "./dist/nivo-bar.es.js",
+        "default": "./dist/nivo-bar.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/boxplot/package.json
+++ b/packages/boxplot/package.json
@@ -27,6 +27,12 @@
     "main": "./dist/nivo-boxplot.cjs.js",
     "module": "./dist/nivo-boxplot.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-boxplot.cjs.js",
+        "import": "./dist/nivo-boxplot.es.js",
+        "default": "./dist/nivo-boxplot.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/bullet/package.json
+++ b/packages/bullet/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-bullet.cjs.js",
     "module": "./dist/nivo-bullet.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-bullet.cjs.js",
+        "import": "./dist/nivo-bullet.es.js",
+        "default": "./dist/nivo-bullet.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/bump/package.json
+++ b/packages/bump/package.json
@@ -23,6 +23,12 @@
     "main": "./dist/nivo-bump.cjs.js",
     "module": "./dist/nivo-bump.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-bump.cjs.js",
+        "import": "./dist/nivo-bump.es.js",
+        "default": "./dist/nivo-bump.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-calendar.cjs.js",
     "module": "./dist/nivo-calendar.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-calendar.cjs.js",
+        "import": "./dist/nivo-calendar.es.js",
+        "default": "./dist/nivo-calendar.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/canvas/package.json
+++ b/packages/canvas/package.json
@@ -21,6 +21,12 @@
     "main": "./dist/nivo-canvas.cjs.js",
     "module": "./dist/nivo-canvas.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-canvas.cjs.js",
+        "import": "./dist/nivo-canvas.es.js",
+        "default": "./dist/nivo-canvas.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/chord/package.json
+++ b/packages/chord/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-chord.cjs.js",
     "module": "./dist/nivo-chord.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-chord.cjs.js",
+        "import": "./dist/nivo-chord.es.js",
+        "default": "./dist/nivo-chord.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/circle-packing/package.json
+++ b/packages/circle-packing/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-circle-packing.cjs.js",
     "module": "./dist/nivo-circle-packing.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-circle-packing.cjs.js",
+        "import": "./dist/nivo-circle-packing.es.js",
+        "default": "./dist/nivo-circle-packing.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -14,6 +14,12 @@
     "main": "./dist/nivo-colors.cjs.js",
     "module": "./dist/nivo-colors.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-colors.cjs.js",
+        "import": "./dist/nivo-colors.es.js",
+        "default": "./dist/nivo-colors.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,12 @@
     "main": "./dist/nivo-core.cjs.js",
     "module": "./dist/nivo-core.es.js",
     "types": "./index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-core.cjs.js",
+        "import": "./dist/nivo-core.es.js",
+        "default": "./dist/nivo-core.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -14,6 +14,12 @@
     "main": "./dist/nivo-express.cjs.js",
     "module": "./dist/nivo-express.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-express.cjs.js",
+        "import": "./dist/nivo-express.es.js",
+        "default": "./dist/nivo-express.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/funnel/package.json
+++ b/packages/funnel/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-funnel.cjs.js",
     "module": "./dist/nivo-funnel.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-funnel.cjs.js",
+        "import": "./dist/nivo-funnel.es.js",
+        "default": "./dist/nivo-funnel.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/generators/package.json
+++ b/packages/generators/package.json
@@ -20,6 +20,12 @@
     "main": "./dist/nivo-generators.cjs.js",
     "module": "./dist/nivo-generators.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-generators.cjs.js",
+        "import": "./dist/nivo-generators.es.js",
+        "default": "./dist/nivo-generators.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -22,6 +22,11 @@
     ],
     "main": "./dist/nivo-geo.cjs.js",
     "module": "./dist/nivo-geo.es.js",
+    "exports": {
+        "require": "./dist/nivo-geo.cjs.js",
+        "import": "./dist/nivo-geo.es.js",
+        "default": "./dist/nivo-geo.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -16,6 +16,12 @@
     "main": "./dist/nivo-grid.cjs.js",
     "module": "./dist/nivo-grid.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-grid.cjs.js",
+        "import": "./dist/nivo-grid.es.js",
+        "default": "./dist/nivo-grid.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/heatmap/package.json
+++ b/packages/heatmap/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-heatmap.cjs.js",
     "module": "./dist/nivo-heatmap.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-heatmap.cjs.js",
+        "import": "./dist/nivo-heatmap.es.js",
+        "default": "./dist/nivo-heatmap.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/legends/package.json
+++ b/packages/legends/package.json
@@ -15,6 +15,12 @@
     "main": "./dist/nivo-legends.cjs.js",
     "module": "./dist/nivo-legends.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-legends.cjs.js",
+        "import": "./dist/nivo-legends.es.js",
+        "default": "./dist/nivo-legends.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-line.cjs.js",
     "module": "./dist/nivo-line.es.js",
     "types": "./index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-line.cjs.js",
+        "import": "./dist/nivo-line.es.js",
+        "default": "./dist/nivo-line.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/marimekko/package.json
+++ b/packages/marimekko/package.json
@@ -14,6 +14,12 @@
     "main": "./dist/nivo-marimekko.cjs.js",
     "module": "./dist/nivo-marimekko.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-marimekko.cjs.js",
+        "import": "./dist/nivo-marimekko.es.js",
+        "default": "./dist/nivo-marimekko.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -24,6 +24,12 @@
     "main": "./dist/nivo-network.cjs.js",
     "module": "./dist/nivo-network.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-network.cjs.js",
+        "import": "./dist/nivo-network.es.js",
+        "default": "./dist/nivo-network.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/parallel-coordinates/package.json
+++ b/packages/parallel-coordinates/package.json
@@ -23,6 +23,12 @@
     "main": "./dist/nivo-parallel-coordinates.cjs.js",
     "module": "./dist/nivo-parallel-coordinates.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-parallel-coordinates.cjs.js",
+        "import": "./dist/nivo-parallel-coordinates.es.js",
+        "default": "./dist/nivo-parallel-coordinates.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/pie/package.json
+++ b/packages/pie/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-pie.cjs.js",
     "module": "./dist/nivo-pie.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-pie.cjs.js",
+        "import": "./dist/nivo-pie.es.js",
+        "default": "./dist/nivo-pie.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/polar-axes/package.json
+++ b/packages/polar-axes/package.json
@@ -21,6 +21,12 @@
     "main": "./dist/nivo-polar-axes.cjs.js",
     "module": "./dist/nivo-polar-axes.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-polar-axes.cjs.js",
+        "import": "./dist/nivo-polar-axes.es.js",
+        "default": "./dist/nivo-polar-axes.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/radar/package.json
+++ b/packages/radar/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-radar.cjs.js",
     "module": "./dist/nivo-radar.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-radar.cjs.js",
+        "import": "./dist/nivo-radar.es.js",
+        "default": "./dist/nivo-radar.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/radial-bar/package.json
+++ b/packages/radial-bar/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-radial-bar.cjs.js",
     "module": "./dist/nivo-radial-bar.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-radial-bar.cjs.js",
+        "import": "./dist/nivo-radial-bar.es.js",
+        "default": "./dist/nivo-radial-bar.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/recompose/package.json
+++ b/packages/recompose/package.json
@@ -19,6 +19,12 @@
     "main": "./dist/nivo-recompose.cjs.js",
     "module": "./dist/nivo-recompose.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-recompose.cjs.js",
+        "import": "./dist/nivo-recompose.es.js",
+        "default": "./dist/nivo-recompose.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/sankey/package.json
+++ b/packages/sankey/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-sankey.cjs.js",
     "module": "./dist/nivo-sankey.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-sankey.cjs.js",
+        "import": "./dist/nivo-sankey.es.js",
+        "default": "./dist/nivo-sankey.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/scales/package.json
+++ b/packages/scales/package.json
@@ -14,6 +14,12 @@
     "main": "./dist/nivo-scales.cjs.js",
     "module": "./dist/nivo-scales.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-scales.cjs.js",
+        "import": "./dist/nivo-scales.es.js",
+        "default": "./dist/nivo-scales.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/scatterplot/package.json
+++ b/packages/scatterplot/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-scatterplot.cjs.js",
     "module": "./dist/nivo-scatterplot.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-scatterplot.cjs.js",
+        "import": "./dist/nivo-scatterplot.es.js",
+        "default": "./dist/nivo-scatterplot.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -14,6 +14,12 @@
     "main": "./dist/nivo-static.cjs.js",
     "module": "./dist/nivo-static.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-static.cjs.js",
+        "import": "./dist/nivo-static.es.js",
+        "default": "./dist/nivo-static.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-stream.cjs.js",
     "module": "./dist/nivo-stream.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-stream.cjs.js",
+        "import": "./dist/nivo-stream.es.js",
+        "default": "./dist/nivo-stream.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/sunburst/package.json
+++ b/packages/sunburst/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-sunburst.cjs.js",
     "module": "./dist/nivo-sunburst.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-sunburst.cjs.js",
+        "import": "./dist/nivo-sunburst.es.js",
+        "default": "./dist/nivo-sunburst.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/swarmplot/package.json
+++ b/packages/swarmplot/package.json
@@ -23,6 +23,12 @@
     "main": "./dist/nivo-swarmplot.cjs.js",
     "module": "./dist/nivo-swarmplot.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-swarmplot.cjs.js",
+        "import": "./dist/nivo-swarmplot.es.js",
+        "default": "./dist/nivo-swarmplot.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -14,6 +14,12 @@
     "main": "./dist/nivo-tooltip.cjs.js",
     "module": "./dist/nivo-tooltip.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-tooltip.cjs.js",
+        "import": "./dist/nivo-tooltip.es.js",
+        "default": "./dist/nivo-tooltip.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/treemap/package.json
+++ b/packages/treemap/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-treemap.cjs.js",
     "module": "./dist/nivo-treemap.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-treemap.cjs.js",
+        "import": "./dist/nivo-treemap.es.js",
+        "default": "./dist/nivo-treemap.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/voronoi/package.json
+++ b/packages/voronoi/package.json
@@ -22,6 +22,12 @@
     "main": "./dist/nivo-voronoi.cjs.js",
     "module": "./dist/nivo-voronoi.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-voronoi.cjs.js",
+        "import": "./dist/nivo-voronoi.es.js",
+        "default": "./dist/nivo-voronoi.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",

--- a/packages/waffle/package.json
+++ b/packages/waffle/package.json
@@ -23,6 +23,12 @@
     "main": "./dist/nivo-waffle.cjs.js",
     "module": "./dist/nivo-waffle.es.js",
     "types": "./dist/types/index.d.ts",
+    "exports": {
+        "types": "./dist/types/index.d.ts",
+        "require": "./dist/nivo-waffle.cjs.js",
+        "import": "./dist/nivo-waffle.es.js",
+        "default": "./dist/nivo-waffle.cjs.js"
+    },
     "files": [
         "README.md",
         "LICENSE.md",


### PR DESCRIPTION
See [this discussion](https://github.com/vitest-dev/vitest/discussions/4233) and https://github.com/BitBloomTech/sift-monitor-ui/pull/1253 .

Basically the `package.json` config values `main`, `module`, and `types` aren't picked up by Vitest, which instead expects the new `exports` syntax.

Before:
```json
"main": "./dist/nivo-core.cjs.js",
"module": "./dist/nivo-core.es.js",
"types": "./dist/types/index.d.ts",
```

After:
```json
"main": "./dist/nivo-core.cjs.js",
"module": "./dist/nivo-core.es.js",
"types": "./dist/types/index.d.ts",
"exports": {
     "types": "./dist/types/index.d.ts",
     "require": "./dist/nivo-core.cjs.js",
     "import": "./dist/nivo-core.es.js",
     "default": "./dist/nivo-core.cjs.js"
},
```

Vitest needs the ESM files (`module`/`import`), which it couldn't find before.

Note the old values are left as-is, so it hopefully it shouldn't break anything that was already working.